### PR TITLE
Automatically deploy when changes are merged into master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
+        with:
+          node-version: 16
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: Continuous Integration
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+      - uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Install Dependencies
+        run: yarn install
+      - name: Build
+        run: yarn build
+      # Note: we only want to deploy when pushing directly to master
+      - name: Deploy
+        if: github.event_name == push && github.ref == "refs/heads/master"
+        run: firebase deploy --token "${{ secrets.FIREBASE_TOKEN }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,5 @@ jobs:
         run: yarn build
       # Note: we only want to deploy when pushing directly to master
       - name: Deploy
-        if: ${{ github.event_name == "push" && github.ref == "refs/heads/master" }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: firebase deploy --token "${{ secrets.FIREBASE_TOKEN }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,5 @@ jobs:
         run: yarn build
       # Note: we only want to deploy when pushing directly to master
       - name: Deploy
-        if: github.event_name == push && github.ref == "refs/heads/master"
+        if: github.event_name == "push" && github.ref == "refs/heads/master"
         run: firebase deploy --token "${{ secrets.FIREBASE_TOKEN }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,5 @@ jobs:
         run: yarn build
       # Note: we only want to deploy when pushing directly to master
       - name: Deploy
-        if: github.event_name == "push" && github.ref == "refs/heads/master"
+        if: ${{ github.event_name == "push" && github.ref == "refs/heads/master" }}
         run: firebase deploy --token "${{ secrets.FIREBASE_TOKEN }}"


### PR DESCRIPTION
I always forget how to deploy to https://dev.hotg.ai/ and need to regenerate firebase tokens, so I thought I'd set up CI to do the deploys automatically.

This PR introduces a set of GitHub Actions which will build the site and *only* deploy to production when we merge changes into `master`. It's essentially what I do for my own personal site.

@kthakore I don't have admin access to this repo, so can you make a couple changes to the security settings?

- [x] Add a `FIREBASE_TOKEN` secret with a valid firebase token
- [x] Set up protected branches so you can't push directly to `master` and the `Continuous Integration` job must be passing before PRs can be merged